### PR TITLE
Adding AuthorizePage & AuthorizeFolder with optional policy

### DIFF
--- a/samples/RazorPages.Samples.Web/Pages/Secure.razor
+++ b/samples/RazorPages.Samples.Web/Pages/Secure.razor
@@ -1,0 +1,17 @@
+﻿@* @page *@
+
+@functions {
+    public void OnGet()
+    {
+        Username = Context.User.Identity.Name;
+    }
+
+    public string Username { get; set; }
+}
+
+@{
+    Layout = "~/Pages/_Layout.cshtml";
+    ViewBag.Title = "Secure Page";
+}
+
+Welcome, <b>@Username</b>

--- a/samples/RazorPages.Samples.Web/Pages/_Layout.cshtml
+++ b/samples/RazorPages.Samples.Web/Pages/_Layout.cshtml
@@ -23,6 +23,7 @@
                 <ul class="nav navbar-nav">
                     <li><a href="/">Home</a></li>
                     <li><a href="/HelloWorld">Hello World</a></li>
+                    <li><a href="/Secure">Secure Page</a></li>
                 </ul>
             </div>
         </div>

--- a/samples/RazorPages.Samples.Web/Startup.cs
+++ b/samples/RazorPages.Samples.Web/Startup.cs
@@ -15,6 +15,7 @@ namespace RazorPages.Samples.Web
         {
             services.AddDbContext<AppDbContext>(options => options.UseInMemoryDatabase());
             services.AddDistributedMemoryCache();
+            services.AddAuthentication();
             services.AddAuthorization();
             services.AddSession();
             services
@@ -25,6 +26,7 @@ namespace RazorPages.Samples.Web
                 .AddRazorPages(options => 
                 {
                     //options.AuthorizeFolder("/", "default");
+                    options.AuthorizePage("/Secure");
                     options.AllowAnonymousToPage("/Index");
                 });
         }
@@ -32,6 +34,12 @@ namespace RazorPages.Samples.Web
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddConsole(LogLevel.Debug);
+
+            app.UseCookieAuthentication(new CookieAuthenticationOptions
+            {
+                AutomaticAuthenticate = true,
+                AutomaticChallenge = true
+            });
 
             app.UseStatusCodePages();
 

--- a/samples/RazorPages.Samples.Web/project.json
+++ b/samples/RazorPages.Samples.Web/project.json
@@ -4,6 +4,7 @@
       "version": "1.0.0",
       "type": "platform"
     },
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
     "Microsoft.AspNetCore.Mvc.RazorPages": "0.1.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0",

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/DependencyInjection/PageModelConventionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/DependencyInjection/PageModelConventionBuilderExtensions.cs
@@ -23,10 +23,24 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
+        public static IPageModelConventionBuilder AuthorizePage(this IPageModelConventionBuilder builder, string path)
+        {
+            var filter = new ConstructableAuthorizationFilter(new AuthorizeAttribute());
+            builder.Add(new PageConvention(path, (m) => m.Filters.Add(filter)));
+            return builder;
+        }
+
         public static IPageModelConventionBuilder AuthorizePage(this IPageModelConventionBuilder builder, string path, string policy)
         {
             var filter = new ConstructableAuthorizationFilter(new AuthorizeAttribute(policy));
             builder.Add(new PageConvention(path, (m) => m.Filters.Add(filter)));
+            return builder;
+        }
+
+        public static IPageModelConventionBuilder AuthorizeFolder(this IPageModelConventionBuilder builder, string path)
+        {
+            var filter = new ConstructableAuthorizationFilter(new AuthorizeAttribute());
+            builder.Add(new FolderConvention(path, (m) => m.Filters.Add(filter)));
             return builder;
         }
 


### PR DESCRIPTION
I made this PR to make it easier to authorize the pages or the folder without requiring a policy. It's similar to the `[Authorize]` that we did a lot in many of our applications.
Regarding the code, I was able to make the policy an optional parameter with `null` as default value, but I find the overloading is better in this case

/cc @rynowak
