### PR TITLE
Modify PageLoader to fully utilize the Razor engine.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/DefaultPageLoader.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Infrastructure/DefaultPageLoader.cs
@@ -114,15 +114,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Compilation
         {
             var document = _engine.CreateCodeDocument(source);
 
-            var parsed = RazorParser.Parse(source);
-            document.SetSyntaxTree(RazorParser.Parse(source));
-            foreach (var error in parsed.Diagnostics)
-            {
-                document.ErrorSink.OnError(error);
-            }
-
-            AddVirtualDocuments(document, relativePath);
-
+            SetImportedDocuments(document, relativePath);
             var @namespace = GetNamespace(relativePath);
             var @class = "Generated_" + Path.GetFileNameWithoutExtension(Path.GetFileName(relativePath));
 
@@ -160,17 +152,19 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Compilation
             }
         }
 
-        private void AddVirtualDocuments(RazorCodeDocument document, string relativePath)
+        private void SetImportedDocuments(RazorCodeDocument document, string relativePath)
         {
+            var importedDocuments = new List<RazorSourceDocument>();
             foreach (var item in _project.EnumerateAscending(relativePath, ".razor"))
             {
                 if (item.Filename == "_PageImports.razor")
                 {
-                    var source = item.ToSourceDocument();
-                    var parsed = RazorParser.Parse(source);
-                    document.AddVirtualSyntaxTree(parsed);
+                    var sourceDocument = item.ToSourceDocument();
+                    importedDocuments.Add(sourceDocument);
                 }
             }
+
+            document.SetImportedDocuments(importedDocuments);
         }
 
         protected virtual CSharpCompilation CreateCompilation(

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Razevolution/DefaultSyntaxTreePhase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Razevolution/DefaultSyntaxTreePhase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Razevolution
             var syntaxTree = document.GetSyntaxTree();
             if (syntaxTree == null)
             {
-                var directiveDescriptors = document.GetDirectiveDescriptors() ?? Enumerable.Empty<RazorDirectiveDescriptor>();
+                var directiveDescriptors = document.GetDirectiveDescriptors();
                 syntaxTree = RazorParser.Parse(document.Source, directiveDescriptors);
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.RazorPages/Razevolution/RazorCodeDocumentExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.RazorPages/Razevolution/RazorCodeDocumentExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.RazorPages.Razevolution.Directives;
 using Microsoft.AspNetCore.Mvc.RazorPages.Razevolution.IR;
 
@@ -10,6 +11,33 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Razevolution
 {
     public static class RazorCodeDocumentExtensions
     {
+        public static IEnumerable<RazorSourceDocument> GetImportedDocuments(this RazorCodeDocument document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            return (IEnumerable<RazorSourceDocument>)document.Items[typeof(IEnumerable<RazorSourceDocument>)] ?? Enumerable.Empty<RazorSourceDocument>();
+        }
+
+        public static void SetImportedDocuments(
+            this RazorCodeDocument document,
+            IEnumerable<RazorSourceDocument> importedDocuments)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (importedDocuments == null)
+            {
+                throw new ArgumentNullException(nameof(importedDocuments));
+            }
+
+            document.Items[typeof(IEnumerable<RazorSourceDocument>)] = importedDocuments;
+        }
+
         public static IEnumerable<RazorDirectiveDescriptor> GetDirectiveDescriptors(this RazorCodeDocument document)
         {
             if (document == null)
@@ -17,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Razevolution
                 throw new ArgumentNullException(nameof(document));
             }
 
-            return (IEnumerable<RazorDirectiveDescriptor>)document.Items[typeof(IEnumerable<RazorDirectiveDescriptor>)];
+            return (IEnumerable<RazorDirectiveDescriptor>)document.Items[typeof(IEnumerable<RazorDirectiveDescriptor>)] ?? Enumerable.Empty<RazorDirectiveDescriptor>();
         }
 
         public static void SetDirectiveDescriptors(


### PR DESCRIPTION
- Changed the number of places we invoke the `RazorParser.Parse`. We used to invoke it multiple times for the same document.
- Prior to this change we'd forcefully set imported syntax trees which resulted in the syntax tree phases effectively no-oping when doing their non-pass work.